### PR TITLE
Add `remappings.txt` for LSP file discovery

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,3 @@
+@std/=lib/forge-std/src/
+ds-test/=lib/forge-std/lib/ds-test/src/
+forge-std/=lib/forge-std/src/


### PR DESCRIPTION
Some Solidity LSP clients require a `remappings.txt` file to resolve import paths. This is a small PR that adds this file. It is generated by the following script:

```
forge remappings > remappings.txt
```