### PR TITLE
Step3 Tau compute length error

### DIFF
--- a/src/verifier/Step3.sol
+++ b/src/verifier/Step3.sol
@@ -547,7 +547,9 @@ library Step3Lib {
         label = new uint8[](1); // Rust's b"t"
         label[0] = 0x74;
 
-        uint256[] memory tau = new uint256[](17);
+        uint256 num_rounds_sat = CommonUtilities.log2(vk.S_comm.N);
+
+        uint256[] memory tau = new uint256[](num_rounds_sat);
 
         for (uint256 index = 0; index < tau.length; index++) {
             (transcript, tau[index]) = KeccakTranscriptLib.squeeze(transcript, ScalarFromUniformLib.curveVesta(), label);


### PR DESCRIPTION
Hi, while working with the verifier, we spot a minor error on Step3 on `compute_tau_primary`. Fixed by copy paste from `compute_tau_secondary` 