### PR TITLE
ci: Switch to Buildjet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit-tests:
     name: Unit Tests
-    runs-on: [self-hosted]
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,6 +19,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
 
       - name: Check formatting
         run: |

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   integration-tests-e2e:
     name: E2E verification
-    runs-on: [self-hosted]
+    runs-on: buildjet-16vcpu-ubuntu-2204
     if:
       github.event.issue.pull_request
       && github.event.issue.state == 'open'


### PR DESCRIPTION
Switches from self-hosted CI to Buildjet, going from 8 vCPU/64GB RAM -> 16 vCPU/64GB RAM. This will save money and maintenance overhead while likely improving performance.

> [!NOTE]
> Feature branches will need to pull in this commit to run the `end2end` tests on Buildjet. Ideally all branches should have the same CI for consistency.
>
> Once that happens, we can test this PR with the `!test` comment on a PR to a feature branch, e.g. `pasta` as it's the most up to date with `main`.

Successful run:
https://github.com/samuelburnham/solidity-verifier/actions/runs/7802235100/job/21279193108
- Ignore the `peter-evans/create-or-update-comment` error, it doesn't work in forks