### PR TITLE
Enable end2end tests on forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,25 @@
-name: test
+name: Run unit tests
 
-on: [workflow_dispatch, push, pull_request]
-
-env:
-  ANVIL_PRIVATE_KEY: ${{secrets.ANVIL_PRIVATE_KEY}}
-  ANVIL_URL: ${{secrets.ANVIL_RPC_URL}}
-
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   integration-tests-e2e:
-    needs: [unit-tests]
+    name: E2E verification
+    # Run on merge_group and workflow_dispatch only
+    if: (github.event_name != 'push' && github.event_name != 'pull_request')  || github.event.action == 'enqueued'
+    runs-on: [self-hosted]
+    env:
+      ANVIL_PRIVATE_KEY: ${{secrets.ANVIL_PRIVATE_KEY}}
+      ANVIL_URL: ${{secrets.ANVIL_RPC_URL}}
     strategy:
       fail-fast: true
-
-    name: E2E verification
-    runs-on: [self-hosted]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -50,7 +53,7 @@ jobs:
     name: Unit Tests
     runs-on: [self-hosted]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -1,0 +1,65 @@
+# Run integration tests when a maintainer comments `!test` on a PR
+name: End to end integration tests
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  ANVIL_PRIVATE_KEY: ${{secrets.ANVIL_PRIVATE_KEY}}
+  ANVIL_URL: ${{secrets.ANVIL_RPC_URL}}
+
+jobs:
+  integration-tests-e2e:
+    strategy:
+      fail-fast: true
+
+    name: E2E verification
+    runs-on: [self-hosted]
+    if:
+      github.event.issue.pull_request
+      && github.event.issue.state == 'open'
+      && contains(github.event.comment.body, '!test')
+      && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout PR branch
+        run: gh pr checkout $PR_NUMBER
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Deploy main contract
+        run: |
+          echo "CONTRACT_ADDRESS=$(forge script script/Deployment.s.sol:NovaVerifierDeployer --fork-url $ANVIL_URL --private-key $ANVIL_PRIVATE_KEY --broadcast --non-interactive | sed -n 's/.*Contract Address: //p' | tail -1)" >> $GITHUB_OUTPUT
+        id: deployment
+
+      - name: Load proof and public parameters
+        run: |
+          python loader.py pp-verifier-key.json pp-compressed-snark.json ${{steps.deployment.outputs.CONTRACT_ADDRESS}} $ANVIL_URL $ANVIL_PRIVATE_KEY
+
+      - name: Check proof verification status
+        run: |
+          [[ $(cast call ${{steps.deployment.outputs.CONTRACT_ADDRESS}} "verify(uint32,uint256[],uint256[],bool)(bool)" "3" "[1]" "[0]" "true" --private-key $ANVIL_PRIVATE_KEY --rpc-url $ANVIL_URL) == true ]] && exit 0 || exit 1
+
+      - name: Comment on successful run
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            End-to-end `!test` action succeeded! :rocket:
+
+            https://github.com/lurk-lab/ci-lab/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
This PR enables end-to-end tests to run on forked PRs with the following triggers:
- `issue_comment`: When a maintainer comments `!test` on a PR, it will trigger the end-to-end tests with full access to repo secrets. This enables the maintainer to carefully review PR comments before approving tests, without having to locally checkout and merge separately. This step is meant to give an early signal rather than be a required status check, so trivial or unrelated PRs can skip it.
- `merge_group`: This triggers the end-to-end tests whenever a PR is added to the merge queue, which this repo doesn't currently have but is used to great effect in https://github.com/lurk-lab/lurk-rs. Requiring the tests to pass when attempting to merge ensures correctness if the above PR comment action isn't run.

Successful runs:
- `issue_comment`: https://github.com/lurk-lab/ci-lab/pull/16 and https://github.com/lurk-lab/ci-lab/actions/runs/6701350814/job/18208641508
- `merge_group`: https://github.com/lurk-lab/lurk-rs/actions/runs/6698173184

TODO:
- [ ] Factor out end-to-end test into separate action to remove code duplication