### PR TITLE
ci: Fail e2e tests when PR base is `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
-name: Run tests
+name: Run unit tests
 
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
@@ -9,9 +8,6 @@ on:
 
 jobs:
   unit-tests:
-    strategy:
-      fail-fast: true
-
     name: Unit Tests
     runs-on: [self-hosted]
     steps:

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -1,4 +1,5 @@
-# Run integration tests when a maintainer comments `!test` on a PR
+# Run integration tests when a maintainer comments `!test` on a PR to feature branch
+# Fails when base branch is `main`, as it doesn't support e2e tests
 name: End to end integration tests
 
 on:
@@ -11,9 +12,6 @@ env:
 
 jobs:
   integration-tests-e2e:
-    strategy:
-      fail-fast: true
-
     name: E2E verification
     runs-on: [self-hosted]
     if:
@@ -21,8 +19,17 @@ jobs:
       && github.event.issue.state == 'open'
       && contains(github.event.comment.body, '!test')
       && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
-      && github.ref != 'refs/heads/main'
     steps:
+      - uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
+      - name: Exit if base branch is `main`
+        if: ${{ steps.comment-branch.outputs.base_ref == 'main' }}
+        run: |
+          echo "Cannot run end2end integration tests on PR targeting `main`"
+          exit 1
+        continue-on-error: false
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive


### PR DESCRIPTION
- Prevents running e2e integration tests on PRs to `main` (tested successfully).
- Removes the `push` trigger for unit test CI in favor of running only on `pull_request` and `workflow_dispatch` rather than every commit, which will save on CI cost in the long run. @storojs72 if you think the `push` trigger is needed I can revert.
- Removes the `fail-fast: true` strategy as it's the default setting,