### PR TITLE
Arithmetics over G2 elements

### DIFF
--- a/src/blocks/grumpkin/Bn256.sol
+++ b/src/blocks/grumpkin/Bn256.sol
@@ -113,3 +113,148 @@ library Bn256 {
         return Bn256AffinePoint(x, y);
     }
 }
+
+// Implementation of arithmetics over G2 elements (required by Zeromorph computations)
+// TODO: implement scalar multiplication (https://github.com/privacy-scaling-explorations/halo2curves/blob/main/src/derive/curve.rs#L1276),
+// which relies on G2 point doubling (https://github.com/privacy-scaling-explorations/halo2curves/blob/main/src/derive/curve.rs#L635)
+library G2 {
+    struct Fq2 {
+        uint256 c0;
+        uint256 c1;
+    }
+
+    struct G2Affine {
+        Fq2 x;
+        Fq2 y;
+    }
+
+    function g2Add(G2Affine memory self, G2Affine memory rhs) public returns (G2Affine memory) {
+        // All affine points have z = (1, 0)
+        Fq2 memory z = Fq2(1, 0);
+        Fq2 memory t0 = multFq2(self.x, rhs.x);
+        Fq2 memory t1 = multFq2(self.y, rhs.y);
+        Fq2 memory t2 = multFq2(z, z);
+        Fq2 memory t3 = addFq2(self.x, self.y);
+        Fq2 memory t4 = addFq2(rhs.x, rhs.y);
+
+        t3 = multFq2(t3, t4);
+        t4 = addFq2(t0, t1);
+        t3 = subFq2(t3, t4);
+        t4 = addFq2(self.x, z);
+        Fq2 memory t5 = addFq2(rhs.x, z);
+
+        t4 = multFq2(t4, t5);
+        t5 = addFq2(t0, t2);
+        t4 = subFq2(t4, t5);
+        t5 = addFq2(self.y, z);
+        Fq2 memory x3 = addFq2(rhs.y, z);
+
+        t5 = multFq2(t5, x3);
+        x3 = addFq2(t1, t2);
+        t5 = subFq2(t5, x3);
+
+        // since z3 = A * t4 and A = (0, 0), so z3 = (0, 0)
+        Fq2 memory z3 = Fq2(0, 0);
+        x3 = mul_by_3b(t2);
+        z3 = addFq2(x3, z3);
+        x3 = subFq2(t1, z3);
+        z3 = addFq2(t1, z3);
+        Fq2 memory y3 = multFq2(x3, z3);
+        t1 = addFq2(t0, t0);
+        t1 = addFq2(t1, t0);
+
+        // since t2 = A * t2 and A = (0, 0), so t2 = (0, 0)
+        t2 = Fq2(0, 0);
+        t4 = mul_by_3b(t4);
+        t1 = addFq2(t1, t2);
+        t2 = subFq2(t0, t2);
+
+        // since t2 = A * t2 and A = (0, 0), so t2 = (0, 0)
+        t2 = Fq2(0, 0);
+        t4 = addFq2(t4, t2);
+        t0 = multFq2(t1, t4);
+        y3 = addFq2(y3, t0);
+        t0 = multFq2(t5, t4);
+        x3 = multFq2(t3, x3);
+        x3 = subFq2(x3, t0);
+        t0 = multFq2(t3, t1);
+        z3 = multFq2(t5, z3);
+        z3 = addFq2(z3, t0);
+
+        Fq2 memory out_x;
+        Fq2 memory out_y;
+
+        (out_x, out_y) = to_g2affine(x3, y3, z3);
+        return G2Affine(out_x, out_y);
+    }
+
+    function invertFq2(Fq2 memory fq2) public returns (Fq2 memory) {
+        uint256 t1 = mulmod(fq2.c1, fq2.c1, Bn256.P_MOD);
+        uint256 t0 = mulmod(fq2.c0, fq2.c0, Bn256.P_MOD);
+
+        t0 = addmod(t0, t1, Bn256.P_MOD);
+        uint256 t = Field.invert(t0, Bn256.P_MOD);
+
+        uint256 c0 = fq2.c0;
+        uint256 c1 = fq2.c1;
+
+        c0 = mulmod(c0, t, Bn256.P_MOD);
+        c1 = mulmod(c1, t, Bn256.P_MOD);
+        c1 = Bn256.negateBase(c1);
+
+        return Fq2(c0, c1);
+    }
+
+    function to_g2affine(Fq2 memory x, Fq2 memory y, Fq2 memory z) public returns (Fq2 memory, Fq2 memory) {
+        Fq2 memory zinv = invertFq2(z);
+        Fq2 memory x_ = multFq2(x, zinv);
+        Fq2 memory y_ = multFq2(y, zinv);
+
+        if (zinv.c0 == 0) {
+            if (zinv.c0 == 0) {
+                return (Fq2(0, 0), Fq2(0, 0));
+            }
+        }
+
+        return (x_, y_);
+    }
+
+    function mul_by_3b(Fq2 memory input) public returns (Fq2 memory) {
+        // B = (0x20753adca9c6bfb81499be5e509e8f8ff21b7c8d3cb039cf1ef69c66bce9b021, 0x01c53b10b0d2fc7e67860f09cc8af9ddf5eee18eaf8748f8ade8371391494176)
+        return multFq2(
+            input,
+            Fq2(
+                0x20753adca9c6bfb81499be5e509e8f8ff21b7c8d3cb039cf1ef69c66bce9b021,
+                0x01c53b10b0d2fc7e67860f09cc8af9ddf5eee18eaf8748f8ade8371391494176
+            )
+        );
+    }
+
+    function subFq2(Fq2 memory self, Fq2 memory other) public view returns (Fq2 memory) {
+        Fq2 memory b_neg = Fq2(Bn256.negateBase(other.c0), Bn256.negateBase(other.c1));
+
+        return Fq2(addmod(self.c0, b_neg.c0, Bn256.P_MOD), addmod(self.c1, b_neg.c1, Bn256.P_MOD));
+    }
+
+    function addFq2(Fq2 memory self, Fq2 memory other) public view returns (Fq2 memory) {
+        return Fq2(addmod(self.c0, other.c0, Bn256.P_MOD), addmod(self.c1, other.c1, Bn256.P_MOD));
+    }
+
+    function multFq2(Fq2 memory self, Fq2 memory other) public view returns (Fq2 memory) {
+        uint256 self_c1;
+        uint256 self_c0;
+        uint256 t1;
+        uint256 t0;
+        uint256 t2;
+        t1 = mulmod(self.c0, other.c0, Bn256.P_MOD);
+        t0 = addmod(self.c0, self.c1, Bn256.P_MOD);
+        t2 = mulmod(self.c1, other.c1, Bn256.P_MOD);
+        self_c1 = addmod(other.c0, other.c1, Bn256.P_MOD);
+        self_c0 = addmod(t1, Bn256.negateBase(t2), Bn256.P_MOD);
+        t1 = addmod(t1, t2, Bn256.P_MOD);
+        t0 = mulmod(t0, self_c1, Bn256.P_MOD);
+        self_c1 = addmod(t0, Bn256.negateBase(t1), Bn256.P_MOD);
+
+        return Fq2(self_c0, self_c1);
+    }
+}

--- a/src/blocks/grumpkin/Zeromorph.sol
+++ b/src/blocks/grumpkin/Zeromorph.sol
@@ -155,7 +155,7 @@ library Pairing {
         require(p1.length == p2.length);
         uint256 elements = p1.length;
         uint256 inputSize = elements * 6;
-        uint256[] memory input = new uint[](inputSize);
+        uint256[] memory input = new uint256[](inputSize);
         for (uint256 i = 0; i < elements; i++) {
             input[i * 6 + 0] = p1[i].inner.x;
             input[i * 6 + 1] = p1[i].inner.y;

--- a/test/grumpkin-curves-tests.t.sol
+++ b/test/grumpkin-curves-tests.t.sol
@@ -282,3 +282,62 @@ contract GrumpkinCurvesContractTests is Test {
         assertEq(point.y, 0x2f7039df869b2f301490e03faedf85d7b6079ee4e389fb09e87425446ec2133d);
     }
 }
+
+contract G2Tests is Test {
+    function testG2Addition() public {
+        G2.Fq2 memory x = G2.Fq2(
+            0x2aa3ce49b85caf169cd1e93e5b01be13688dd65660371ff08e6351a6b031028f,
+            0x2e6c1f338a4fd2cafe04883a9721f890448bcb8ea26bf2aefbb891267318f63c
+        );
+        G2.Fq2 memory y = G2.Fq2(
+            0x242215fb12e6bd34d1cf146dfd3ec7f6ce0240978e17191ff0829d15eca3e761,
+            0x0e1fa4978a7aa2206a1e230edeefaf91ccbfaf8587b9921bc2a7c92d94803f2b
+        );
+
+        G2.G2Affine memory a = G2.G2Affine(x, y);
+        G2.G2Affine memory b = G2.G2Affine(x, y);
+
+        G2.G2Affine memory sum = G2.g2Add(a, b);
+
+        assertEq(sum.x.c0, 0x25fe1ef5bd43a6ae6de0880632bbeb5087686c53a4189192f58a8afb1778c76d);
+        assertEq(sum.x.c1, 0x07dc5f2daaa695fd9eb789ec6ad02e07ac2cf24495a3da6cfb6b6e586585cc36);
+        assertEq(sum.y.c0, 0x2f18e5677cdb4afa5ac1b227bf6d3868d597edffc903fa65cd8d5e8111d5671f);
+        assertEq(sum.y.c1, 0x240fd5c6b31aaed215732836ce1328a2cd81bb73c60c9f3e2327bb5c99374b8c);
+    }
+
+    function testFq2Negation() public {
+        G2.Fq2 memory a = G2.Fq2(
+            0x2aa3ce49b85caf169cd1e93e5b01be13688dd65660371ff08e6351a6b031028f,
+            0x2e6c1f338a4fd2cafe04883a9721f890448bcb8ea26bf2aefbb891267318f63c
+        );
+
+        G2.Fq2 memory negation = G2.subFq2(a, a);
+
+        assertEq(negation.c0, 0);
+        assertEq(negation.c1, 0);
+    }
+
+    function testFq2Addition() public {
+        G2.Fq2 memory a = G2.Fq2(
+            0x2aa3ce49b85caf169cd1e93e5b01be13688dd65660371ff08e6351a6b031028f,
+            0x2e6c1f338a4fd2cafe04883a9721f890448bcb8ea26bf2aefbb891267318f63c
+        );
+
+        G2.Fq2 memory addition = G2.addFq2(a, a);
+
+        assertEq(addition.c0, 0x24e34e208f87be0381538cc6348223c9399a421b57fc7553e0a6173687e507d7);
+        assertEq(addition.c1, 0x2c73eff4336e056c43b8cabeacc298c2f1962c8bdc661ad0bb5096360db4ef31);
+    }
+
+    function testFq2Multiplication() public {
+        G2.Fq2 memory a = G2.Fq2(
+            0x2aa3ce49b85caf169cd1e93e5b01be13688dd65660371ff08e6351a6b031028f,
+            0x2e6c1f338a4fd2cafe04883a9721f890448bcb8ea26bf2aefbb891267318f63c
+        );
+
+        G2.Fq2 memory addition = G2.multFq2(a, a);
+
+        assertEq(addition.c0, 0x0ba0bf2ab3bd48bcaca08fa1bc4cf4a0924c481a37a02bbd0433e1b8dadb6d28);
+        assertEq(addition.c1, 0x1b69ffffc834b76a1ca5b1848799af5b59b8a326137d8c3d84073ac925f8d252);
+    }
+}

--- a/test/pp-spartan-step-5.t.sol
+++ b/test/pp-spartan-step-5.t.sol
@@ -460,8 +460,10 @@ contract PpSpartanStep5Computations is Test {
         uint256[] memory eval_output_arr
     ) private pure returns (uint256[] memory) {
         uint256 index = 0;
-        uint256[] memory eval_vec =
-        new uint256[](eval_left_arr.length + eval_right_arr.length + eval_output_arr.length + eval_A_B_C_z.length + evals_E.length + evals_val.length);
+        uint256[] memory eval_vec = new uint256[](
+            eval_left_arr.length + eval_right_arr.length + eval_output_arr.length + eval_A_B_C_z.length + evals_E.length
+                + evals_val.length
+        );
 
         for (uint256 i = 0; i < eval_A_B_C_z.length; i++) {
             eval_vec[index] = eval_A_B_C_z[i];


### PR DESCRIPTION
This work is motivated by https://github.com/lurk-lab/arecibo/pull/145, which improves previous one and finally adds completed Zeromorph PCS to Arecibo.

Zeromorph requires performing some computations over G2 elements within Bn256 curve (addition / scalar multiplication) and this PR actually adds sketch of the library that can be further utilised by higher-level Zeromorph step library and e2e contract eventually. 

Currently only addition of G2 elements is supported and scalar multiplication should be delivered in subsequent PRs.