### PR TITLE
ci: Port changes from `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,66 +1,29 @@
-name: Run tests
+name: Run unit tests
 
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:
 
 jobs:
-  integration-tests-e2e:
-    name: E2E verification
-    # Run on merge_group and workflow_dispatch only
-    if: (github.event_name != 'push' && github.event_name != 'pull_request')  || github.event.action == 'enqueued'
-    runs-on: [self-hosted]
-    env:
-      ANVIL_PRIVATE_KEY: ${{secrets.ANVIL_PRIVATE_KEY}}
-      ANVIL_URL: ${{secrets.ANVIL_RPC_URL}}
-    strategy:
-      fail-fast: true
+  unit-tests:
+    name: Unit Tests
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-
-      - name: Deploy main contract
-        run: |
-          echo "CONTRACT_ADDRESS=$(forge script script/Deployment.s.sol:NovaVerifierDeployer --fork-url $ANVIL_URL --private-key $ANVIL_PRIVATE_KEY --broadcast --non-interactive | sed -n 's/.*Contract Address: //p' | tail -1)" >> $GITHUB_OUTPUT
-        id: deployment
-
-      - name: Load proof and public parameters
-        run: |
-          python loader.py pp-verifier-key.json pp-compressed-snark.json ${{steps.deployment.outputs.CONTRACT_ADDRESS}} $ANVIL_URL $ANVIL_PRIVATE_KEY
-
-      - name: Check proof verification status
-        run: |
-          [[ $(cast call ${{steps.deployment.outputs.CONTRACT_ADDRESS}} "verify(uint32,uint256[],uint256[],bool)(bool)" "3" "[1]" "[0]" "true" --private-key $ANVIL_PRIVATE_KEY --rpc-url $ANVIL_URL) == true ]] && exit 0 || exit 1
-
-  unit-tests:
-    strategy:
-      fail-fast: true
-
-    name: Unit Tests
-    runs-on: [self-hosted]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
 
       - name: Check formatting
         run: |

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -1,4 +1,5 @@
-# Run integration tests when a maintainer comments `!test` on a PR
+# Run integration tests when a maintainer comments `!test` on a PR to feature branch
+# Fails when base branch is `main`, as it doesn't support e2e tests
 name: End to end integration tests
 
 on:
@@ -11,17 +12,24 @@ env:
 
 jobs:
   integration-tests-e2e:
-    strategy:
-      fail-fast: true
-
     name: E2E verification
-    runs-on: [self-hosted]
+    runs-on: buildjet-16vcpu-ubuntu-2204
     if:
       github.event.issue.pull_request
       && github.event.issue.state == 'open'
       && contains(github.event.comment.body, '!test')
       && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
     steps:
+      - uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
+      - name: Exit if base branch is `main`
+        if: ${{ steps.comment-branch.outputs.base_ref == 'main' }}
+        run: |
+          echo "Cannot run end2end integration tests on PR targeting `main`"
+          exit 1
+        continue-on-error: false
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/src/Utilities.sol
+++ b/src/Utilities.sol
@@ -291,9 +291,7 @@ library PolyLib {
         }
 
         uint256 coeff_index = 0;
-        uint256[] memory coeffs = new uint256[](
-            poly.coeffs_except_linear_term.length + 1
-        );
+        uint256[] memory coeffs = new uint256[](poly.coeffs_except_linear_term.length + 1);
         coeffs[coeff_index] = poly.coeffs_except_linear_term[0];
         coeff_index++;
         coeffs[coeff_index] = linear_term;

--- a/test/pp-spartan-step5-tests.t.sol
+++ b/test/pp-spartan-step5-tests.t.sol
@@ -460,9 +460,10 @@ contract PpSpartanStep5Computations is Test {
         uint256[] memory eval_output_arr
     ) private pure returns (uint256[] memory) {
         uint256 index = 0;
-        uint256[] memory eval_vec =
-        new uint256[](eval_left_arr.length + eval_right_arr.length + eval_output_arr.length + eval_A_B_C_z.length + evals_E.length + evals_val.length);
-
+        uint256[] memory eval_vec = new uint256[](
+            eval_left_arr.length + eval_right_arr.length + eval_output_arr.length + eval_A_B_C_z.length + evals_E.length
+                + evals_val.length
+        );
         for (uint256 i = 0; i < eval_A_B_C_z.length; i++) {
             eval_vec[index] = eval_A_B_C_z[i];
             index++;


### PR DESCRIPTION
- Switches test runners to Buildjet (#35)
- Enables `!test` comment to trigger e2e tests on forked PRs (#42)
- Fixes `forge fmt` errors

This PR can be a model for ports to other feature branches, e.g. `grumpkin`, `zeromorph`, etc.

> [!NOTE]
> Because the forked PR fix doesn't exist yet on the base branch, the e2e `!test` doesn't seem to trigger the required status check. We should thus temporarily remove the requirement (since the test succeeded below) and test further once merged.