### PR TITLE
Automatic generating of proof / public parameters JSONs

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -55,9 +55,13 @@ jobs:
           echo "CONTRACT_ADDRESS=$(forge script script/Deployment.s.sol:NovaVerifierDeployer --fork-url $ANVIL_URL --private-key $ANVIL_PRIVATE_KEY --broadcast --non-interactive | sed -n 's/.*Contract Address: //p' | tail -1)" >> $GITHUB_OUTPUT
         id: deployment
 
+      - name: Generate proof and public parameters from commit hash
+        run: |
+          python ci_pasta_keys_verifier_script.py https://github.com/lurk-lab/Nova.git d5f5fb5e557b99cb111f2d5693aa34fe30722750
+
       - name: Load proof and public parameters
         run: |
-          python loader.py pp-verifier-key.json pp-compressed-snark.json ${{steps.deployment.outputs.CONTRACT_ADDRESS}} $ANVIL_URL $ANVIL_PRIVATE_KEY
+          python loader.py vk.json compressed-snark.json ${{steps.deployment.outputs.CONTRACT_ADDRESS}} $ANVIL_URL $ANVIL_PRIVATE_KEY
 
       - name: Check proof verification status
         run: |

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -34,15 +34,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Parse PR comment
+      - name: Set environment variables for generate_contract_input.py (Nova URL and commit)
         id: parse-comment
         run:
-            # Extract NOVA_URL and NOVA_COMMIT from the comment body
-            export NOVA_URL=$(echo "${{ github.event.comment.body }}" | grep -oE 'NOVA_URL=(.*?)[[:space:]]' | cut -d'=' -f2 | xargs)
-            export NOVA_COMMIT=$(echo "${{ github.event.comment.body }}" | grep -oE 'NOVA_COMMIT=(.*?)[[:space:]]' | cut -d'=' -f2 | xargs)
-            echo "::set-env name=NOVA_URL::$NOVA_URL"
-            echo "::set-env name=NOVA_COMMIT::$NOVA_COMMIT"    
-
+          echo "::set-env name=NOVA_URL::https://github.com/lurk-lab/Nova"
+          echo "::set-env name=NOVA_COMMIT::ea4f75c225cb29f523780858ec84f1ff51c229bc"
+        
       - name: Checkout PR branch
         run: gh pr checkout $PR_NUMBER
         env:

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -34,6 +34,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Parse PR comment
+        id: parse-comment
+        run:
+            # Extract NOVA_URL and NOVA_COMMIT from the comment body
+            export NOVA_URL=$(echo "${{ github.event.comment.body }}" | grep -oE 'NOVA_URL=(.*?)[[:space:]]' | cut -d'=' -f2 | xargs)
+            export NOVA_COMMIT=$(echo "${{ github.event.comment.body }}" | grep -oE 'NOVA_COMMIT=(.*?)[[:space:]]' | cut -d'=' -f2 | xargs)
+            echo "::set-env name=NOVA_URL::$NOVA_URL"
+            echo "::set-env name=NOVA_COMMIT::$NOVA_COMMIT"    
+
       - name: Checkout PR branch
         run: gh pr checkout $PR_NUMBER
         env:
@@ -57,7 +66,7 @@ jobs:
 
       - name: Generate proof and public parameters from commit hash
         run: |
-          python ci_pasta_keys_verifier_script.py https://github.com/lurk-lab/Nova.git d5f5fb5e557b99cb111f2d5693aa34fe30722750
+          python ci_pasta_keys_verifier_script.py $NOVA_URL $NOVA_COMMIT
 
       - name: Load proof and public parameters
         run: |

--- a/ci_pasta_keys_verifier_script.py
+++ b/ci_pasta_keys_verifier_script.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+import os
+
+# python3 ci_pasta_keys_verifier_script.py https://github.com/lurk-lab/Nova.git d5f5fb5e557b99cb111f2d5693aa34fe30722750
+if __name__ == "__main__":
+    # Configurations
+    nova_repo_url = sys.argv[1]
+    nova_commit_hash = sys.argv[2]
+    target_directory = "verify_cache"
+    nova_directory = "nova"
+
+    # Main logic
+    if os.path.exists(target_directory):
+        subprocess.run(['rm', '-rf', target_directory], check=True)
+    os.mkdir(target_directory)
+    os.mkdir(target_directory + "/" + nova_directory)
+    os.chdir(target_directory)
+    os.system(f"git clone {nova_repo_url} {nova_directory}")
+    os.chdir(nova_directory)
+    os.system(f"git checkout {nova_commit_hash}")
+    os.system(f"cargo +nightly test solidity_compatibility_e2e_pasta --release -- --ignored")
+    print("Copy generated keys form Nova...")
+    os.system(f"cp vk.json compressed-snark.json ../../.")

--- a/ci_pasta_keys_verifier_script.py
+++ b/ci_pasta_keys_verifier_script.py
@@ -1,16 +1,90 @@
 import subprocess
 import sys
 import os
+import re
 
-# python3 ci_pasta_keys_verifier_script.py https://github.com/lurk-lab/Nova.git d5f5fb5e557b99cb111f2d5693aa34fe30722750
+file_path = 'rust-reference-info.txt'
+
+solidity_compatibility_e2e_pasta_code = '''
+  #[test]
+  #[ignore]
+  fn solidity_compatibility_e2e() {
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
+    test_ivc_nontrivial_with_compression_with::<G1, G2>(true);
+  }
+'''
+
+
+def parse_variables_from_file(file_path):
+    variables = {}
+    with open(file_path, 'r') as file:
+        content = file.read()
+        # Define regex patterns for matching variables
+        nova_url_pattern = r'\$NOVA_URL\s*=\s*\"(.+?)\"'
+        nova_commit_pattern = r'\$NOVA_COMMIT\s*=\s*\"(.+?)\"'
+
+        # Match variables using regular expressions
+        nova_url_match = re.search(nova_url_pattern, content)
+        nova_commit_match = re.search(nova_commit_pattern, content)
+
+        # Extract matched variables
+        if nova_url_match:
+            variables['NOVA_URL'] = nova_url_match.group(1)
+        if nova_commit_match:
+            variables['NOVA_COMMIT'] = nova_commit_match.group(1)
+
+    return variables
+
+
+def add_function_before_last_brace(file_path, function_definition):
+    # Read the content of the file
+    with open(file_path, 'r') as file:
+        lines = file.readlines()
+
+    # Find the position of the last "}" character
+    last_brace_index = None
+    for i in range(len(lines) - 1, -1, -1):
+        if '}' in lines[i]:
+            last_brace_index = i
+            break
+
+    if last_brace_index is None:
+        raise ValueError("No closing brace found in the file.")
+
+    # Insert the function definition before the last "}" position
+    lines.insert(last_brace_index, f"\n{function_definition}\n")
+
+    # Write the updated content back to the file
+    with open(file_path, 'w') as file:
+        file.writelines(lines)
+
+
+# python3 ci_pasta_keys_verifier_script.py https://github.com/artem-bakuta/Nova.git 3838031868ca3f2783c01299546849860bfd36d2
 if __name__ == "__main__":
+    nova_repo_arg = ""
+    nova_commit_arg = ""
+
+    if len(sys.argv) > 1:
+        nova_repo_arg = sys.argv[1]
+        nova_commit_arg = sys.argv[2]
+
     # Configurations
-    nova_repo_url = sys.argv[1]
-    nova_commit_hash = sys.argv[2]
+    parsed_variables = parse_variables_from_file(file_path)
+    nova_repo_url = nova_repo_arg if nova_repo_arg else parsed_variables['NOVA_URL']
+    nova_commit_hash = nova_commit_arg if nova_commit_arg else parsed_variables['NOVA_COMMIT']
+    print("Pulling project from: " + nova_repo_url + " " + nova_commit_hash)
     target_directory = "verify_cache"
     nova_directory = "nova"
 
     # Main logic
+    print("Deleting generated jsons from solidity-verifier project...")
+    os.system(f"rm -rf neptune-constants-U24-pallas.json")
+    os.system(f"rm -rf neptune-constants-U24-vesta.json")
+    os.system(f"rm -rf pp-compressed-snark.json")
+    os.system(f"rm -rf pp-verifier-key.json")
+    os.system(f"rm -rf verifier-key.json")
+
     if os.path.exists(target_directory):
         subprocess.run(['rm', '-rf', target_directory], check=True)
     os.mkdir(target_directory)
@@ -19,6 +93,10 @@ if __name__ == "__main__":
     os.system(f"git clone {nova_repo_url} {nova_directory}")
     os.chdir(nova_directory)
     os.system(f"git checkout {nova_commit_hash}")
-    os.system(f"cargo +nightly test solidity_compatibility_e2e_pasta --release -- --ignored")
-    print("Copy generated keys form Nova...")
+
+    # Build the Nova project
+    file_path = 'src/lib.rs'
+    add_function_before_last_brace(file_path, solidity_compatibility_e2e_pasta_code)
+    os.system(f"cargo test solidity_compatibility_e2e --release -- --ignored")
+    print("Copy generated keys from Nova...")
     os.system(f"cp vk.json compressed-snark.json ../../.")

--- a/generate_contract_input.py
+++ b/generate_contract_input.py
@@ -49,7 +49,7 @@ def add_function_before_last_brace(file_path, function_definition):
         file.writelines(lines)
 
 
-# python3 generate_contract_input.py https://github.com/artem-bakuta/Nova.git 3838031868ca3f2783c01299546849860bfd36d2
+# python generate_contract_input.py https://github.com/artem-bakuta/Nova.git 3838031868ca3f2783c01299546849860bfd36d2
 if __name__ == "__main__":
     nova_repo_arg = ""
     nova_commit_arg = ""

--- a/generate_contract_input.py
+++ b/generate_contract_input.py
@@ -25,30 +25,6 @@ def parse_variables_from_file(file_path):
 
     return variables
 
-
-def add_function_before_last_brace(file_path, function_definition):
-    # Read the content of the file
-    with open(file_path, 'r') as file:
-        lines = file.readlines()
-
-    # Find the position of the last "}" character
-    last_brace_index = None
-    for i in range(len(lines) - 1, -1, -1):
-        if '}' in lines[i]:
-            last_brace_index = i
-            break
-
-    if last_brace_index is None:
-        raise ValueError("No closing brace found in the file.")
-
-    # Insert the function definition before the last "}" position
-    lines.insert(last_brace_index, f"\n{function_definition}\n")
-
-    # Write the updated content back to the file
-    with open(file_path, 'w') as file:
-        file.writelines(lines)
-
-
 # python generate_contract_input.py https://github.com/artem-bakuta/Nova.git 3838031868ca3f2783c01299546849860bfd36d2
 if __name__ == "__main__":
     nova_repo_arg = ""

--- a/generate_contract_input.py
+++ b/generate_contract_input.py
@@ -5,17 +5,6 @@ import re
 
 file_path = 'rust-reference-info.txt'
 
-solidity_compatibility_e2e_pasta_code = '''
-  #[test]
-  #[ignore]
-  fn solidity_compatibility_e2e() {
-    type G1 = pasta_curves::pallas::Point;
-    type G2 = pasta_curves::vesta::Point;
-    test_ivc_nontrivial_with_compression_with::<G1, G2>(true);
-  }
-'''
-
-
 def parse_variables_from_file(file_path):
     variables = {}
     with open(file_path, 'r') as file:
@@ -60,7 +49,7 @@ def add_function_before_last_brace(file_path, function_definition):
         file.writelines(lines)
 
 
-# python3 ci_pasta_keys_verifier_script.py https://github.com/artem-bakuta/Nova.git 3838031868ca3f2783c01299546849860bfd36d2
+# python3 generate_contract_input.py https://github.com/artem-bakuta/Nova.git 3838031868ca3f2783c01299546849860bfd36d2
 if __name__ == "__main__":
     nova_repo_arg = ""
     nova_commit_arg = ""
@@ -77,14 +66,6 @@ if __name__ == "__main__":
     target_directory = "verify_cache"
     nova_directory = "nova"
 
-    # Main logic
-    print("Deleting generated jsons from solidity-verifier project...")
-    os.system(f"rm -rf neptune-constants-U24-pallas.json")
-    os.system(f"rm -rf neptune-constants-U24-vesta.json")
-    os.system(f"rm -rf pp-compressed-snark.json")
-    os.system(f"rm -rf pp-verifier-key.json")
-    os.system(f"rm -rf verifier-key.json")
-
     if os.path.exists(target_directory):
         subprocess.run(['rm', '-rf', target_directory], check=True)
     os.mkdir(target_directory)
@@ -95,8 +76,6 @@ if __name__ == "__main__":
     os.system(f"git checkout {nova_commit_hash}")
 
     # Build the Nova project
-    file_path = 'src/lib.rs'
-    add_function_before_last_brace(file_path, solidity_compatibility_e2e_pasta_code)
-    os.system(f"cargo test solidity_compatibility_e2e --release -- --ignored")
+    os.system(f"cargo test solidity_compatibility_e2e_pasta --release -- --ignored")
     print("Copy generated keys from Nova...")
     os.system(f"cp vk.json compressed-snark.json ../../.")

--- a/rust-reference-info.txt
+++ b/rust-reference-info.txt
@@ -1,4 +1,4 @@
-# ci_pasta_keys_verifier_script.py script params
+# generate_contract_input.py script params
 
 # NOVA_URL variable
 $NOVA_URL = "https://github.com/lurk-lab/Nova.git"

--- a/rust-reference-info.txt
+++ b/rust-reference-info.txt
@@ -1,0 +1,7 @@
+# ci_pasta_keys_verifier_script.py script params
+
+# NOVA_URL variable
+$NOVA_URL = "https://github.com/lurk-lab/Nova.git"
+
+# NOVA_COMMIT variable
+$NOVA_COMMIT = "d5f5fb5e557b99cb111f2d5693aa34fe30722750"


### PR DESCRIPTION
Added script for autogenerating `vk.json` and `compressed-snark.json` for pasta. 

Link to the script will also attach: [script](https://gist.github.com/artem-bakuta/0478534f0df4fafa8e491947847fb320)

It's also added in PR.

Partially fixes https://github.com/lurk-lab/solidity-verifier/issues/24

References https://github.com/lurk-lab/Nova/pull/38